### PR TITLE
Fix typos

### DIFF
--- a/continuity/digInTheIntermediateValueTheorem.tex
+++ b/continuity/digInTheIntermediateValueTheorem.tex
@@ -115,7 +115,7 @@ Now, let's contrast this with a time when the conclusion of the Intermediate Val
   \end{selectAll}
 \end{question}
 
-Building on the question above, it is not difficult to see that  each of the hypothesis of the Intermediate Value Theorem is necessary.
+Building on the question above, it is not difficult to see that  each of the hypotheses of the Intermediate Value Theorem is necessary.
 
 
 Let's see the Intermediate Value Theorem in action.
@@ -193,7 +193,7 @@ The Intermediate Value Theorem can be used to show that curves cross:
 		    &= e^2\cdot \answer[given]{1} - 2\cdot e\cos(\answer[given]{1})
 		   \end{align*}
 		   Since $e>2$ and $0 < \cos(1)<1$ we see that the expression above is
-		   positive. Therefore, $h(1)<0<h(e)$, and by the Intermediate Value Theorem, there exist a number $c$ in $(1,e)$ such that
+		   positive. Therefore, $h(1)<0<h(e)$, and by the Intermediate Value Theorem, there exists a number $c$ in $(1,e)$ such that
 		  \[h(c)=0.\]
 		    But this means that 
 		    \[ f(c)-g(c)=0, \]


### PR DESCRIPTION
The plural form of "hypothesis" is "hypotheses."